### PR TITLE
Implement tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A command represents a user-triggerable process for interacting with the bot and
 
 The `Context` wrapper class holds information about the context in which the command was run. This inclues the message parsed by the bot, the author, the guild, and settings obtained for the execution to occur.
 
-- reply(content: string) - Reply to the command message
+-   reply(content: string) - Reply to the command message
 
 ## Providers
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -2,6 +2,7 @@ import { Client as ErisClient, ClientEvents, ClientOptions as ErisClientOptions 
 import { existsSync, lstatSync, readdirSync } from 'fs';
 import * as path from 'path';
 
+import { Command } from './commands/Command';
 import { CommandRegistry } from './commands/CommandRegistry';
 import { Module } from './modules/Module';
 import { MemoryProvider } from './providers/MemoryProvider';
@@ -21,6 +22,7 @@ const DEFAULT_CLIENT_OPTIONS: ClientOptions = {};
 export declare interface Client extends ErisClient {
 	on: ClientEvents<this> & {
 		(event: 'moduleAdd', listener: (module: Module) => void): Client;
+		(event: 'commandAdd', listener: (command: Command) => void): Client;
 	};
 }
 
@@ -60,21 +62,12 @@ export class Client extends ErisClient {
 	}
 
 	/**
-	 * Stop the bots
-	 */
-	async stop() {
-		this.logger.info('Cleaning up...');
-
-		await this.modulesWillUnload();
-		this.disconnect({ reconnect: false });
-		await this.modulesDidUnload();
-
-		this.logger.info('Done.');
-		process.exit();
-	}
-
-	/**
-	 * Start modules
+	 * Initialize the modules and connect to Discord.
+	 *
+	 * Initialization Order:
+	 * - `moduleWillInit` - module tasks are started after this function has resolved.
+	 * - `connect` - connet to Discord
+	 * - `moduleDidInit`
 	 */
 	async connect(token = this.token) {
 		this.token = token;
@@ -107,6 +100,20 @@ export class Client extends ErisClient {
 	}
 
 	/**
+	 * Stop the client, disconnecting it from Discord and exiting the process.
+	 */
+	async stop() {
+		this.logger.info('Cleaning up...');
+
+		await this.modulesWillUnload();
+		this.disconnect({ reconnect: false });
+		await this.modulesDidUnload();
+
+		this.logger.info('Done.');
+		process.exit();
+	}
+
+	/**
 	 * Add a module to the Client. It is guaranteed that modules will be intialized
 	 * in the order that they appear in the array.
 	 *
@@ -116,12 +123,12 @@ export class Client extends ErisClient {
 		for (const module of modules) {
 			const constructedModule = new module(this);
 
-			constructedModule.getCommands();
 			this.emit('moduleAdd', constructedModule);
 
 			this.modules.set(module.name, constructedModule);
 			if (this.connectionStatus === ConnectionStatus.Ready) {
 				await constructedModule.moduleWillInit();
+				await constructedModule.startTasks();
 				await constructedModule.moduleDidInit();
 			}
 		}
@@ -221,6 +228,7 @@ export class Client extends ErisClient {
 	async modulesWillUnload() {
 		for (const mdl of this.modules) {
 			await mdl[1].moduleWillUnload();
+			await mdl[1].stopTasks();
 		}
 
 		this.logger.success('Modules unloaded.');

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -3,7 +3,7 @@ import { existsSync, lstatSync, readdirSync } from 'fs';
 import * as path from 'path';
 
 import { CommandRegistry } from './commands/CommandRegistry';
-import { Module } from './Module';
+import { Module } from './modules/Module';
 import { MemoryProvider } from './providers/MemoryProvider';
 import { GuildSettings, SettingsProvider } from './providers/SettingsProvider';
 import { createLogger } from './utils';
@@ -40,7 +40,7 @@ export class Client extends ErisClient {
 
 	public readonly options: ClientOptions;
 
-	constructor(opts: Partial<ClientOptions>) {
+	constructor(opts?: Partial<ClientOptions>) {
 		super('', opts);
 
 		this.options = {
@@ -197,6 +197,8 @@ export class Client extends ErisClient {
 	async postInitializeModules() {
 		for (const mdl of this.modules) {
 			await mdl[1].moduleDidInit();
+			// Start tasks but don't await - blocks the rest of the bot startup flow if offset is used.
+			mdl[1].startTasks();
 		}
 
 		this.logger.success('Modules post-initialized.');

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -1,4 +1,4 @@
-import { Module } from '../Module';
+import { Module } from '../modules/Module';
 import { Context } from './Context';
 
 /**

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -89,6 +89,11 @@ export class Command {
 					? inhibitor.apply(this.options.module, [ctx])
 					: inhibitor(ctx)));
 			} catch (err) {
+				ctx.client.logger.warn(
+					'Error in inhibitor',
+					inhibitor.name,
+					'- preventing command execution.'
+				);
 				isInhibited = false;
 			}
 

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -39,6 +39,7 @@ export interface CommandOptions {
 	disabled: boolean;
 	inhibitors: CommandInhibitor[];
 	aliases: string[];
+	module?: Module;
 }
 
 const DEFAULT_COMMAND_OPTIONS: CommandOptions = {
@@ -66,16 +67,13 @@ export class Command {
 	 * Run the command in the given context.
 	 */
 	async execute(ctx: Context) {
-		const inhibited = await this.callInhibitors(ctx);
-		if (inhibited) {
+		if (await this.callInhibitors(ctx)) {
 			return;
 		}
-		this.handler(ctx);
-	}
 
-	protected async evaluatePermission(ctx: Context) {
-		if (ctx.member) {
-		}
+		return this.options.module
+			? this.handler.apply(this.options.module, [ctx])
+			: this.handler(ctx);
 	}
 
 	/**
@@ -87,7 +85,9 @@ export class Command {
 
 		for (const inhibitor of this.inhibitors) {
 			try {
-				isInhibited = !(await inhibitor(ctx));
+				isInhibited = !(await (this.options.module
+					? inhibitor.apply(this.options.module, [ctx])
+					: inhibitor(ctx)));
 			} catch (err) {
 				isInhibited = false;
 			}

--- a/src/commands/CommandRegistry.ts
+++ b/src/commands/CommandRegistry.ts
@@ -91,6 +91,7 @@ export class CommandRegistry {
 			.on('moduleAdd', (m) => {
 				this.registerCommand(...Array.from(m.getCommands().values()));
 			})
+			.on('commandAdd', (c) => this.registerCommand(c))
 			.on('messageCreate', (message) => this._handleMessage(message));
 	}
 

--- a/src/commands/CommandRegistry.ts
+++ b/src/commands/CommandRegistry.ts
@@ -110,6 +110,6 @@ export class CommandRegistry {
 			return;
 		}
 
-		await cmd.execute(new Context(this.client, message));
+		await cmd.execute(new Context(this.client, message, cmd));
 	}
 }

--- a/src/commands/Context.ts
+++ b/src/commands/Context.ts
@@ -3,6 +3,8 @@ import { Message, MessageContent, MessageFile } from 'eris';
 import { Client } from '../Client';
 import { PagedEmbed, PagedEmbedPage } from '../structures/PagedEmbed';
 import { ChannelTypes } from '../types/Discord';
+import { createLogger, Logger } from '../utils';
+import { Command } from './Command';
 
 /**
  * Wrapper class for the context in which a command is executed.
@@ -23,7 +25,18 @@ export class Context {
 	 */
 	readonly channel = this.message.channel;
 
-	constructor(readonly client: Client, readonly message: Message) {}
+	/**
+	 * Short-cut access to the client's logger.
+	 */
+	readonly logger: Logger;
+
+	constructor(
+		readonly client: Client,
+		readonly message: Message,
+		readonly command: Command
+	) {
+		this.logger = createLogger('Command-' + command.name);
+	}
 
 	/**
 	 * The guild in which the command was executed.
@@ -50,7 +63,7 @@ export class Context {
 	reply(content: MessageContent, file?: MessageFile) {
 		if (typeof content === 'string') {
 			content = {
-				content: `<@${this.message.author.id}>, ${content}`
+				content: `<@${this.message.author.id}>, ${content}`,
 			};
 		}
 		return this.message.channel.createMessage(

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export {
 } from './commands/Command';
 export { Context } from './commands/Context';
 
-export { Module, command, disabled } from './Module';
+export { Module, command, disabled } from './modules/Module';
 
 export { MemoryProvider } from './providers/MemoryProvider';
 export { GuildSettings } from './providers/SettingsProvider';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export {
 } from './commands/Command';
 export { Context } from './commands/Context';
 
-export { Module, command, disabled } from './modules/Module';
+export { Module, command, disabled, task } from './modules';
 
 export { MemoryProvider } from './providers/MemoryProvider';
 export { GuildSettings } from './providers/SettingsProvider';

--- a/src/modules/Module.ts
+++ b/src/modules/Module.ts
@@ -71,6 +71,7 @@ export abstract class Module extends EventEmitter {
 		)) {
 			const command = Reflect.getMetadata('command', this, method);
 			if (command && !this.commands.get(command.name)) {
+				command.options.module = this;
 				this.commands.set(command.name, command);
 			}
 		}
@@ -117,7 +118,7 @@ export abstract class Module extends EventEmitter {
 	 */
 	static command = (opts?: CommandOptions) => {
 		return (
-			target: Module,
+			module: Module,
 			name: string,
 			descriptor: TypedPropertyDescriptor<ModuleCommandHandler>
 		) => {
@@ -127,8 +128,8 @@ export abstract class Module extends EventEmitter {
 
 			Reflect.defineMetadata(
 				'command',
-				new Command(name, descriptor.value, opts),
-				target,
+				new Command(name, descriptor.value, { module, ...opts }),
+				module,
 				name
 			);
 		};

--- a/src/modules/Module.ts
+++ b/src/modules/Module.ts
@@ -3,21 +3,20 @@ import 'reflect-metadata';
 import { Client } from 'eris';
 import { EventEmitter } from 'events';
 
-import { Command, CommandOptions, ModuleCommandHandler } from './commands/Command';
-import { createLogger } from './utils';
-
-type ModuleTask = () => void;
-type ModuleGroup = {};
+import { Command, CommandOptions, ModuleCommandHandler } from '../commands/Command';
+import { createLogger } from '../utils';
+import { ModuleTask, ModuleTaskOptions } from './ModuleTask';
 
 export abstract class Module extends EventEmitter {
 	readonly commands = new Map<string, Command>();
-	readonly groups = new Map<string, ModuleGroup>();
 	readonly tasks = new Map<string, ModuleTask>();
 	readonly logger = createLogger(this.constructor.name);
 
 	constructor(readonly client: Client) {
 		super();
-		this.commands = new Map();
+
+		this.getCommands();
+		this.getTasks();
 	}
 
 	/**
@@ -79,6 +78,40 @@ export abstract class Module extends EventEmitter {
 	}
 
 	/**
+	 * Fetch the commands defined on the module using decorators. Calling this method will add
+	 * commands defined using the `@command` decorator to the modules `commands` map.
+	 *
+	 * **It is not necessary to call this function at runtime!** The Client object the module is
+	 * attatched to calls this during module initialization.
+	 */
+	getTasks() {
+		// Prevent parsing meta-data when you don't need to.
+		if (this.tasks.size > 0) {
+			return this.tasks;
+		}
+
+		for (const method of Object.getOwnPropertyNames(
+			this.constructor.prototype
+		)) {
+			const task = Reflect.getMetadata('task', this, method);
+			if (task && !this.tasks.get(task.name)) {
+				this.tasks.set(task.name, task);
+				task.module = this;
+			}
+		}
+		return this.tasks;
+	}
+
+	/**
+	 * Start the module's tasks.
+	 */
+	public async startTasks() {
+		const promises: Promise<void>[] = [];
+		this.getTasks().forEach((v) => promises.push(v.start()));
+		return await Promise.all(promises);
+	}
+
+	/**
 	 * Mark a module method as a command.
 	 * @param commandOpts
 	 */
@@ -113,50 +146,32 @@ export abstract class Module extends EventEmitter {
 			descriptor.value.disable();
 		}
 	};
+
+	/**
+	 * Mark a module method as a command.
+	 * @param commandOpts
+	 */
+	static task = (opts?: Partial<ModuleTaskOptions>) => {
+		return (
+			target: Module,
+			name: string,
+			descriptor: TypedPropertyDescriptor<() => Promise<void>>
+		) => {
+			if (!descriptor.value) {
+				return;
+			}
+
+			Reflect.defineMetadata(
+				'task',
+				new ModuleTask(target, name, descriptor.value, opts),
+				target,
+				name
+			);
+		};
+	};
 }
 
 // Static module exports for ease of access.
 export const command = Module.command;
 export const disabled = Module.disabled;
-
-/**
- * Mark a module method as a task.
- * @param commandOpts
- */
-export const group = (groupOpts?: {}) => {
-	return (
-		module: Module,
-		name: string,
-		descriptor: TypedPropertyDescriptor<ModuleGroup>
-	) => {
-		module.groups.set(name, {});
-	};
-};
-
-/**
- * Mark a module method as a task.
- */
-export const task = () => {
-	return (
-		module: Module,
-		name: string,
-		descriptor: TypedPropertyDescriptor<ModuleTask>
-	) => {
-		module.tasks.set(name, () => {});
-	};
-};
-
-/**
- * Mark a module method as a client event.
- */
-export const event = (name: string) => {
-	return (
-		module: Module,
-		key: string,
-		descriptor: TypedPropertyDescriptor<(...args: any[]) => any>
-	) => {
-		if (descriptor.value) {
-			module.client.on(name, descriptor.value);
-		}
-	};
-};
+export const task = Module.task;

--- a/src/modules/ModuleTask.ts
+++ b/src/modules/ModuleTask.ts
@@ -1,0 +1,81 @@
+import { waitFor } from '../utils';
+import { Module } from './Module';
+
+export interface ModuleTaskOptions {
+	runEvery: number;
+	runFor: number;
+	offset: number;
+}
+
+const DEFAULT_TASK_OPTIONS: ModuleTaskOptions = {
+	runEvery: 0,
+	runFor: 0,
+	offset: 0,
+};
+
+/**
+ * Represents a task runnable by a module.
+ */
+export class ModuleTask {
+	public runCount = 0;
+
+	private timer?: NodeJS.Timeout;
+
+	constructor(
+		readonly module: Module,
+		readonly taskName: string,
+		readonly handler: () => void | Promise<void>,
+		readonly options: Partial<ModuleTaskOptions> = DEFAULT_TASK_OPTIONS
+	) {
+		this.options = { ...DEFAULT_TASK_OPTIONS, ...options };
+		this.handler = this.handler.bind(module);
+	}
+
+	/**
+	 * Start a task. If the task is asyncrhonous, this will resolve after the first run-through.
+	 */
+	async start() {
+		if (this.options.offset) {
+			await waitFor(this.options.offset);
+		}
+
+		if (this.options.runEvery) {
+			this.timer = setInterval(
+				() => this.trigger.apply(this.module),
+				this.options.runEvery
+			);
+		}
+
+		// Run the trigger for the first time.
+		return await this.trigger.apply(this.module);
+	}
+
+	/**
+	 * Stop the task from running. If the task is set to loop, the next trigger will be cancelled.
+	 */
+	stop() {
+		if (this.options.runEvery && this.timer) {
+			clearInterval(this.timer);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Trigger the task's handler.
+	 */
+	async trigger() {
+		try {
+			await this.handler.apply(this.module);
+		} catch (err) {
+			console.error('Error in task', this.taskName);
+			console.error(err);
+		}
+
+		this.runCount++;
+
+		if (this.runCount === this.options.runFor && this.timer) {
+			clearInterval(this.timer);
+		}
+	}
+}

--- a/src/modules/ModuleTask.ts
+++ b/src/modules/ModuleTask.ts
@@ -28,7 +28,6 @@ export class ModuleTask {
 		readonly options: Partial<ModuleTaskOptions> = DEFAULT_TASK_OPTIONS
 	) {
 		this.options = { ...DEFAULT_TASK_OPTIONS, ...options };
-		this.handler = this.handler.bind(module);
 	}
 
 	/**
@@ -41,13 +40,13 @@ export class ModuleTask {
 
 		if (this.options.runEvery) {
 			this.timer = setInterval(
-				() => this.trigger.apply(this.module),
+				() => this.trigger(),
 				this.options.runEvery
 			);
 		}
 
 		// Run the trigger for the first time.
-		return await this.trigger.apply(this.module);
+		return await this.trigger();
 	}
 
 	/**
@@ -68,8 +67,8 @@ export class ModuleTask {
 		try {
 			await this.handler.apply(this.module);
 		} catch (err) {
-			console.error('Error in task', this.taskName);
-			console.error(err);
+			this.module.logger.error('Error in task', this.taskName);
+			this.module.logger.error(err);
 		}
 
 		this.runCount++;

--- a/src/modules/ModuleTask.ts
+++ b/src/modules/ModuleTask.ts
@@ -17,7 +17,14 @@ const DEFAULT_TASK_OPTIONS: ModuleTaskOptions = {
  * Represents a task runnable by a module.
  */
 export class ModuleTask {
-	public runCount = 0;
+	/**
+	 * How many times the task has run.
+	 */
+	get loop() {
+		return this._loop;
+	}
+
+	private _loop = 0;
 
 	private timer?: NodeJS.Timeout;
 
@@ -71,10 +78,36 @@ export class ModuleTask {
 			this.module.logger.error(err);
 		}
 
-		this.runCount++;
+		this._loop++;
 
-		if (this.runCount === this.options.runFor && this.timer) {
+		if (this._loop === this.options.runFor && this.timer) {
 			clearInterval(this.timer);
 		}
+	}
+
+	/**
+	 * Sets the maximum loop count for the task.
+	 * @param count
+	 */
+	setMaxLoopCount(count: number) {
+		this.options.runFor = count;
+	}
+
+	/**
+	 * Set the current loop number.
+	 * @param i
+	 */
+	setLoop(i: number) {
+		this._loop = i;
+		return this;
+	}
+
+	/**
+	 * Set the interval of the loop.
+	 * @param interval
+	 */
+	setLoopInterval(interval: number) {
+		this.options.runEvery = interval;
+		return this;
 	}
 }

--- a/src/modules/ModuleUtils.ts
+++ b/src/modules/ModuleUtils.ts
@@ -1,0 +1,65 @@
+import { Command, CommandOptions, ModuleCommandHandler } from '../commands/Command';
+import { Module } from './Module';
+import { ModuleTask, ModuleTaskOptions } from './ModuleTask';
+
+/**
+ * Mark a module method as a command.
+ * @param commandOpts
+ */
+export const command = (opts?: CommandOptions) => {
+	return (
+		module: Module,
+		name: string,
+		descriptor: TypedPropertyDescriptor<ModuleCommandHandler>
+	) => {
+		if (!descriptor.value) {
+			return;
+		}
+
+		Reflect.defineMetadata(
+			'command',
+			new Command(name, descriptor.value, {
+				module,
+				...opts,
+			}),
+			module,
+			name
+		);
+	};
+};
+
+/**
+ * Mark a command as disabled.
+ */
+export const disabled = (
+	module: new () => Module,
+	name: string,
+	descriptor: TypedPropertyDescriptor<ModuleCommandHandler>
+) => {
+	if (descriptor.value instanceof Command) {
+		descriptor.value.disable();
+	}
+};
+
+/**
+ * Mark a module method as a command.
+ * @param commandOpts
+ */
+export const task = (opts?: Partial<ModuleTaskOptions>) => {
+	return (
+		target: Module,
+		name: string,
+		descriptor: TypedPropertyDescriptor<() => Promise<void>>
+	) => {
+		if (!descriptor.value) {
+			return;
+		}
+
+		Reflect.defineMetadata(
+			'task',
+			new ModuleTask(target, name, descriptor.value, opts),
+			target,
+			name
+		);
+	};
+};

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,0 +1,2 @@
+export { Module } from './Module';
+export { task, command, disabled } from './ModuleUtils';

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,0 +1,22 @@
+import { Client, Module } from '../src';
+
+class TestModule extends Module {
+	public runResult = Date.now();
+
+	moduleWillInit() {
+		this.logger.info('Initializing');
+	}
+	moduleDidInit() {
+		this.logger.info('done');
+	}
+
+	@Module.task({ runEvery: 1e3, offset: 1e3, runFor: 3 })
+	async testTask() {
+		this.logger.debug('task test: ', Date.now() - this.runResult);
+		this.runResult = Date.now();
+	}
+}
+
+const client = new Client();
+client.addModule(TestModule);
+client.connect('');

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,4 +1,4 @@
-import { Client, Module } from '../src';
+import { Client, Context, Module } from '../src';
 
 class TestModule extends Module {
 	public runResult = Date.now();
@@ -14,6 +14,11 @@ class TestModule extends Module {
 	async testTask() {
 		this.logger.debug('task test: ', Date.now() - this.runResult);
 		this.runResult = Date.now();
+	}
+
+	@Module.command()
+	async test(ctx: Context) {
+		ctx.reply(this.runResult.toString());
 	}
 }
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,24 +1,20 @@
-import { Client, Context, Module } from '../src';
+import { Client, Command, Module } from '../src';
 
 class TestModule extends Module {
 	public runResult = Date.now();
 
 	moduleWillInit() {
 		this.logger.info('Initializing');
+
+		this.addCommand(
+			new Command('uwu', async (ctx) => {
+				ctx.reply('uwu');
+			})
+		);
 	}
+
 	moduleDidInit() {
 		this.logger.info('done');
-	}
-
-	@Module.task({ runEvery: 1e3, offset: 1e3, runFor: 3 })
-	async testTask() {
-		this.logger.debug('task test: ', Date.now() - this.runResult);
-		this.runResult = Date.now();
-	}
-
-	@Module.command()
-	async test(ctx: Context) {
-		ctx.reply(this.runResult.toString());
 	}
 }
 


### PR DESCRIPTION
# Tasks
Tasks provide an easy way of integrating looping timer logic into modules. They can be specified to run every `x` milliseconds, with an initial start offset of `y` milliseconds, and can be told to run `z` times.

## Usage

The `@Module.task()` decorator can be used to add tasks to modules. It takes a ` ModuleTaskOptions` as arguments, which contain the parameters talked about above.

```ts
class TestModule extends Module {
    @Module.task({ runFor: 3, runEvery: 3e3, offset: 3e3 });
    async task() {
        console.log('Meep!');
    }
} 
````

### ModuleTask
- `options` {ModuleTaskOptions} - the task's options.
- `name` {string} - the name of the task, used for identifying and dynamically starting/stopping the task.
- `runCount` {number} - how many times the task has run.

### ModuleTaskOptions
The options for the task.
- `runEvery` {number} - runs the task with the specified interval, with times in milliseconds. **Default:** `0`
- `runFor` {number} - runs the task for a fixed number of loops. **Default:** `0`
- `offset` {number} - the delay after which a task will run, with times in milliseconds. **Default:** `0`

## To-do List

- [x] Fix `this` not binding correrctly during handler exectution.
- [x] Generalize logic and move it into ~~`Module.ts`~~ `ModuleUtil.ts`
- [x] Add logic for easier dynamic modification of the task's options.